### PR TITLE
Fallback for cameraEnabled and isOnline

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -24,6 +24,10 @@ body:
         required: true
       - label: This issue is not a duplicate issue of any [previous issues](https://github.com/ThomasLomas/ha-starlinghomehub/issues?q=is%3Aissue+label%3A%22bug%22+)..
         required: true
+      - label: My Starling Home Hub is running the latest firmware.
+        required: true
+      - label: My Home Assistant Integration is using Starling Home Hub API v2
+        required: true
 - type: textarea
   attributes:
     label: "Describe the issue"
@@ -43,7 +47,7 @@ body:
     required: true
 - type: textarea
   attributes:
-    label: What Nest devices are you using?
+    label: What Starling Home Hub connected devices are you using?
     description: "Not all devices are supported and so it is important to know what devices you are using."
     value: |
       1.

--- a/custom_components/starling_home_hub/const.py
+++ b/custom_components/starling_home_hub/const.py
@@ -8,7 +8,7 @@ LOGGER: Logger = getLogger(__package__)
 
 NAME = "Starling Home Hub Integration"
 DOMAIN = "starling_home_hub"
-VERSION = "1.8.0"
+VERSION = "1.8.1"
 ATTRIBUTION = "Based on the Starling Home Hub Developer Connect API"
 
 CONF_ENABLE_RTSP_STREAM = "enable_rtsp_stream"

--- a/custom_components/starling_home_hub/entities/camera.py
+++ b/custom_components/starling_home_hub/entities/camera.py
@@ -55,7 +55,8 @@ class StarlingHomeHubBaseCamera(StarlingHomeHubEntity, Camera):
     @property
     def is_on(self) -> bool:
         """Return True if the camera is on."""
-        return self.get_device() is not None and self.get_device().properties.get("cameraEnabled", False)
+        device = self.get_device()
+        return device is not None and device.properties.get("cameraEnabled", False)
 
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None

--- a/custom_components/starling_home_hub/entities/camera.py
+++ b/custom_components/starling_home_hub/entities/camera.py
@@ -50,12 +50,12 @@ class StarlingHomeHubBaseCamera(StarlingHomeHubEntity, Camera):
     def available(self) -> bool:
         """Return True if entity is available."""
         device = self.get_device()
-        return device is not None and device.properties["cameraEnabled"] and device.properties["isOnline"]
+        return device is not None and device.properties.get("cameraEnabled", False) and device.properties.get("isOnline", False)
 
     @property
     def is_on(self) -> bool:
         """Return True if the camera is on."""
-        return self.get_device().properties["cameraEnabled"]
+        return self.get_device() is not None and self.get_device().properties.get("cameraEnabled", False)
 
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None

--- a/custom_components/starling_home_hub/manifest.json
+++ b/custom_components/starling_home_hub/manifest.json
@@ -13,5 +13,5 @@
   "documentation": "https://github.com/ThomasLomas/ha-starlinghomehub",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/ThomasLomas/ha-starlinghomehub/issues",
-  "version": "1.8.0"
+  "version": "1.8.1"
 }


### PR DESCRIPTION
Adds fallback handling for camera properties to prevent KeyError exceptions when properties are missing from device responses, while also improving bug report template clarity.
- Replaces direct dictionary access with .get() method calls for safer property retrieval
- Updates bug report template to clarify Starling Home Hub requirements and device context